### PR TITLE
Fix builds for mitmproxy 10.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ ARG openssl_version openssl_dir openssl_config_dir cryptography_dir
 RUN apt update && \
     apt install -y \
     curl build-essential libffi-dev pkg-config
-RUN curl https://sh.rustup.rs | sh -s -- -y
+RUN curl -L https://sh.rustup.rs | sh -s -- -y
 
 # Download and compile OpenSSL
-RUN curl https://www.openssl.org/source/openssl-${openssl_version}.tar.gz | tar -xvz -C /tmp
+RUN curl -L https://www.openssl.org/source/openssl-${openssl_version}.tar.gz | tar -xvz -C /tmp
 WORKDIR /tmp/openssl-${openssl_version}
 RUN ./config --prefix=${openssl_dir} --openssldir=${openssl_config_dir} -Wl,-Bsymbolic-functions -fPIC shared
 RUN make -j $(nproc)
@@ -34,7 +34,7 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 ENV OPENSSL_DIR=${openssl_dir}
 RUN python3 -m venv venv
 RUN . ${cryptography_dir}/venv/bin/activate && \
-    python3 -m pip install cryptography --no-binary cryptography -v
+    OPENSSL_STATIC=1 OPENSSL_DIR="${OPENSSL_DIR}" python3 -m pip install cryptography --no-binary cryptography -v
 
 # This is the main mitmproxy container that will be run. We use a new image so
 # the build tools are not left over in the final image.

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ RUN make install_sw
 WORKDIR ${cryptography_dir}
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV OPENSSL_DIR=${openssl_dir}
+ENV OPENSSL_STATIC=1
 RUN python3 -m venv venv
 RUN . ${cryptography_dir}/venv/bin/activate && \
-    OPENSSL_STATIC=1 OPENSSL_DIR="${OPENSSL_DIR}" python3 -m pip install cryptography --no-binary cryptography -v
+    python3 -m pip install cryptography --no-binary cryptography -v
 
 # This is the main mitmproxy container that will be run. We use a new image so
 # the build tools are not left over in the final image.


### PR DESCRIPTION
### Changes:

First, downloading old OpenSSL versions now requires telling curl to follow redirects. Second, it seems that a change in a recent Python cryptography version now requires the `OPENSSL_STATIC` option to be set in order for mitmproxy to actually use the custom OpenSSL version.

- [x] I have read and agreed to the [Code of Conduct](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CODE_OF_CONDUCT.md).
- [x] I have read and complied with the [contributing guidelines](https://github.com/PretendoNetwork/Pretendo/blob/master/.github/CONTRIBUTING.md).
- [ ] What I'm implementing was an [approved issue](../issues?q=is%3Aopen+is%3Aissue+label%3Aapproved).
- [x] I have tested all of my changes.